### PR TITLE
Bug in MatrixEnumerator

### DIFF
--- a/SharpMath/Geometry/MatrixEnumerator.cs
+++ b/SharpMath/Geometry/MatrixEnumerator.cs
@@ -26,7 +26,7 @@ namespace SharpMath.Geometry
         public bool MoveNext()
         {
             _index++;
-            return _index < _matrix.ColumnCount + _matrix.RowCount;
+            return _index < _matrix.ColumnCount * _matrix.RowCount;
         }
 
         public void Reset()


### PR DESCRIPTION
Matrix index should be less than (column * row) instead of (column + row)